### PR TITLE
Rename redirect back or to

### DIFF
--- a/lib/generators/sorcery/templates/initializer.rb
+++ b/lib/generators/sorcery/templates/initializer.rb
@@ -21,6 +21,15 @@ Rails.application.config.sorcery.configure do |config|
   #
   # config.save_return_to_url =
 
+  # Set whether to override Sorcery's 'redirect_back_or_to' by Rails 7's 'redirect_back_or_to'.
+  # Rails 7 released a new method called 'redirect_back_or_to' as a replacement for 'redirect_back'.
+  # That may conflict with the method by the same name defined by Sorcery.
+  # If you set this option to true, Sorcery's redirect_back_or_to will be overridden by
+  # the method of the same name defined in Rails 7.
+  # Default: `false`
+  #
+  # config.use_redirect_back_or_to_by_rails =
+
   # Set domain option for cookies; Useful for remember_me submodule.
   # Default: `nil`
   #

--- a/lib/sorcery/controller.rb
+++ b/lib/sorcery/controller.rb
@@ -96,7 +96,16 @@ module Sorcery
 
       # used when a user tries to access a page while logged out, is asked to login,
       # and we want to return him back to the page he originally wanted.
-      def redirect_back_or_to(url, flash_hash = {})
+      def redirect_back_or_to(...)
+        if Config.use_redirect_back_or_to_by_rails
+          super
+        else
+          warn('[WARNING] `redirect_back_or_to` overrides the method of the same name defined in Rails 7. If you want to avoid the override, you can set `config.use_redirect_back_or_to_by_rails = true`.')
+          sorcery_redirect_back_or_to(...)
+        end
+      end
+
+      def sorcery_redirect_back_or_to(url, flash_hash = {})
         redirect_to(session[:return_to_url] || url, flash: flash_hash)
         session[:return_to_url] = nil
       end

--- a/lib/sorcery/controller/config.rb
+++ b/lib/sorcery/controller/config.rb
@@ -20,6 +20,9 @@ module Sorcery
         attr_accessor :after_logout
         attr_accessor :after_remember_me
 
+        # set whether to override Sorcery's 'redirect_back_or_to' by Rails 7's 'redirect_back_or_to'.
+        attr_accessor :use_redirect_back_or_to_by_rails
+
         def init!
           @defaults = {
             :@user_class                           => nil,
@@ -32,7 +35,8 @@ module Sorcery
             :@after_logout                         => Set.new,
             :@after_remember_me                    => Set.new,
             :@save_return_to_url                   => true,
-            :@cookie_domain                        => nil
+            :@cookie_domain                        => nil,
+            :@use_redirect_back_or_to_by_rails     => false
           }
         end
 


### PR DESCRIPTION
## 概要
Rails 7の`redirect_back_or_to`メソッドがSorceryで定義されている`redirect_back_or_to`にオーバーライドされてしまっているので、オプションの有効でRails側のメソッドを優先できるようにします。

## 変更内容
- オプション `use_redirect_back_or_to_by_rails `を追加
  - trueにセットすることでRailsの`redirect_back_or_to`をsuperで参照します
  - falseにセットしている場合は`redirect_back_or_to`の呼び出し時に、「Railsのメソッドがオーバーライドされている」旨を警告する
- オプションの切り替えに対応するテストを追加
  - 検証方法として、事前にconfigをセットした後にそれぞれ`request.referer`, `session[:return_to_url]` を渡して指定のURLにリダイレクトをするか確認する。
    - Rails側が優先されている場合は`request.referer`の値に従ったリダイレクトが実行されます
    - Sorcery側が優先されている場合は`session[:return_to_url]`に従ったリダイレクトが実行されます 